### PR TITLE
fix: Updating config builder so config values are forced to be string

### DIFF
--- a/src/js/data.js
+++ b/src/js/data.js
@@ -62,7 +62,8 @@ DataFactory.prototype = {
         } catch(e) {
           throw new Error("Invalid text column.")
         }
-        slideActive = (dataObj[i][config.slider.start_at_card]) ? dataObj[i][config.slider.start_at_card].$t : false;
+        slideActive = (dataObj[i][config.slider.start_at_card]) ? dataObj[i][config.slider.start_at_card].$t :
+          (typeof config.slider.start_at_card === typeof 0) ? config.slider.start_at_card : false;
       } else if (card_lookup[i]) {
         slideTitle = card_lookup[i].title;
         slideText = card_lookup[i].text;
@@ -266,10 +267,10 @@ DataFactory.prototype = {
     for(var key in configSubset) {
       let formattedHeaders = {}
       Object.keys(configSubset[key]).map(function(header) {
-        if(header === 'url' || header === 'datetime_format' || header === 'start_at_card') {
+        if(header === 'url' || header === 'datetime_format' || (header === 'start_at_card' && typeof configSubset[key][header] === typeof 0)) {
           formattedHeaders[header] = configSubset[key][header]
         } else {
-          formattedHeaders[header] = "gsx$" + configSubset[key][header].replace(/\s/g, '').toLowerCase()
+          formattedHeaders[header] = "gsx$" + (configSubset[key][header]).toString().replace(/\s/g, '').toLowerCase()
         }
       })
       config[key] = formattedHeaders


### PR DESCRIPTION
Now the value `start_at_card` can be either string or num regardless of whether cards are read in from spreadsheet or local json. Fixes #61 
```
{
  "data": {...},
  "chart": {...},
  "slider": {
    "title_column_name": "slide title",
    "text_column_name":  "slide text",
    "start_at_card": 0 // works for explicit num e.g. `0` OR column name from spreadsheet e.g. `"slide active"`
  }
}
```
Not a fan of the mixed approach bc it means additional checks to ensure that the value gets propagated. I think it'd be a better approach if we were explicit in the docs about how to create these config values— either use spreadsheet columns for all card config vals OR use locally declared strings via json.